### PR TITLE
Reformat vector table in protocol.md

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -242,35 +242,35 @@ messages in ASCII encoding.
 
 Message from Alice to Bob.
 
-Variable       | Value
--------------: | :----
-![K_a'][Ka']   | `77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a`
-![K_b'][Kb']   | `5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb`
-![N_{ab}][Nab] | `0`
-![M_n][Mn]     | `The quick brown fox`
-               |
-![K_a][Ka]     | `8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a`
-![K_b][Kb]     | `de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f`
-![K_s][Ks]     | `4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742`
-               |
-![T][T]        | `9c44389f462d35d0672faf73a5e118f8b9f5c340bbe8d340e2b947c205ea4fa3`
+| Variable       | Value                                                              |
+|---------------:|:-------------------------------------------------------------------|
+| ![K_a'][Ka']   | `77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a` |
+| ![K_b'][Kb']   | `5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb` |
+| ![N_{ab}][Nab] | `0`                                                                |
+| ![M_n][Mn]     | `The quick brown fox`                                              |
+|                |                                                                    |
+| ![K_a][Ka]     | `8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a` |
+| ![K_b][Kb]     | `de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f` |
+| ![K_s][Ks]     | `4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742` |
+|                |                                                                    |
+| ![T][T]        | `9c44389f462d35d0672faf73a5e118f8b9f5c340bbe8d340e2b947c205ea4fa3` |
 
 #### Vector 2
 
 Message from Bob to Alice.
 
-Variable       | Value
--------------: | :----
-![K_a'][Ka']   | `fee1deadfee1deadfee1deadfee1deadfee1deadfee1deadfee1deadfee1dead`
-![K_b'][Kb']   | `b105f00db105f00db105f00db105f00db105f00db105f00db105f00db105f00d`
-![N_{ba}][Nba] | `100`
-![M_n][Mn]     | `The quick brown fox`
-               |
-![K_a][Ka]     | `872f435bb8b89d0e3ad62aa2e511074ee195e1c39ef6a88001418be656e3c376`
-![K_b][Kb]     | `d1b6941bba120bcd131f335da15778d9c68dadd398ae61cf8e7d94484ee65647`
-![K_s][Ks]     | `4b1ee05fcd2ae53ebe4c9ec94915cb057109389a2aa415f26986bddebf379d67`
-               |
-![T][T]        | `06476f1f314b06c7f96e5dc62b2308268cbdb6140aefeeb55940731863032277`
+| Variable       | Value                                                              |
+|---------------:|:-------------------------------------------------------------------|
+| ![K_a'][Ka']   | `fee1deadfee1deadfee1deadfee1deadfee1deadfee1deadfee1deadfee1dead` |
+| ![K_b'][Kb']   | `b105f00db105f00db105f00db105f00db105f00db105f00db105f00db105f00d` |
+| ![N_{ba}][Nba] | `100`                                                              |
+| ![M_n][Mn]     | `The quick brown fox`                                              |
+|                |                                                                    |
+| ![K_a][Ka]     | `872f435bb8b89d0e3ad62aa2e511074ee195e1c39ef6a88001418be656e3c376` |
+| ![K_b][Kb]     | `d1b6941bba120bcd131f335da15778d9c68dadd398ae61cf8e7d94484ee65647` |
+| ![K_s][Ks]     | `4b1ee05fcd2ae53ebe4c9ec94915cb057109389a2aa415f26986bddebf379d67` |
+|                |                                                                    |
+| ![T][T]        | `06476f1f314b06c7f96e5dc62b2308268cbdb6140aefeeb55940731863032277` |
 
 ### Reference implementation
 


### PR DESCRIPTION
It was accidentally using a different dialect of Markdown