### PR TITLE
ci: Remove reference to missing glome_test.cc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - name: check libglome format
       run: |
         clang-format --Werror --dry-run --style=google \
-          glome.c glome.h glome_test.c
+          glome.c glome.h
     - name: check glome-cli format
       run: |
         clang-format --Werror --dry-run --style=google cli/main.c


### PR DESCRIPTION
Testing glome_test.c is for when the tests are merged
