### PR TITLE
meson.build: force finding an absolute path for cli/test.sh

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,7 @@ glome_test = executable('glome_test', 'glome_test.c', dependencies : glib_dep,
   link_with : glome_lib, include_directories : glome_incdir)
 test('glome', glome_test)
 
-cli_test = find_program('cli/test.sh')
+cli_test = find_program(meson.current_source_dir() + '/cli/test.sh')
 test('cli', cli_test,
   args : glome_cli,
   timeout : 120)


### PR DESCRIPTION
Currently meson ends up resolving the script path to the literal string
"cli/test.sh", which breaks when trying to run the tests from a
different directory than the source directory. A common reason one might
want to do this is if running the tests via "ninja test" instead of
"meson test".

TESTED=Tests successfully run with "ninja test" with this change.