### PR TITLE
cli/test.sh: resolve 'bash' through $PATH

### DIFF
--- a/cli/test.sh
+++ b/cli/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The current test script shebang assumes that bash is installed as
/bin/bash. While common, this is not standard or guaranteed to be the
case across Linux distros (e.g. NixOS) let alone other Unix systems
(e.g. OpenBSD where it's usually in /usr/local).

Resolving through /usr/bin/env is the common de facto standard, and all
reasonable operating systems carry a working /usr/bin/env.

Note that this goes against the Google Shell Style[1]. The Google Shell
Style is objectively wrong in that regard, and encourages writing non
portable scripts for no good reason.

[1] https://google.github.io/styleguide/shellguide.html#which-shell-to-use