### PR TITLE
login: README and more documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Building the GLOME library requires
  - Meson >=0.49.2
  - OpenSSL headers >=1.1.1
  - glib-2.0 (for glome-login as well as tests)
+ - libconfuse (for glome-login)
 
 ### Instructions
 

--- a/login/README.md
+++ b/login/README.md
@@ -1,0 +1,46 @@
+# glome-login
+
+This binary implements the client side of the
+[GLOME Login](../docs/glome-login.md) protocol. It is written to be a
+replacement of login(1).
+
+## Usage
+
+ 1. Create a configuration file, see [example.cfg](example.cfg).
+ 1. Try it out by running `glome-login -c glome.cfg -- root`
+
+## Installation
+
+The installation is dependent on what system you are running.
+
+### systemd
+
+Create a override file for the getty instance e.g. in
+`/etc/systemd/system/serial-getty@.service.d/glome.conf`.
+
+```
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty -l /usr/local/sbin/glome-login \
+  -o '-- \\u' --keep-baud 115200,38400,9600 %I $TERM
+```
+
+Alternatively or for a normal VTY, use
+`/etc/systemd/system/getty@.service.d/glome.conf`.
+
+```
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty -l /usr/local/sbin/glome-login \
+  -o '-- \\u' --noclear %I $TERM
+```
+
+## Troubleshooting
+
+glome-login uses error tags to communicate errors.
+
+### no-service-key
+
+This error means that `glome-login` could not figure out what service key to
+use. This most likely means that you have not specified a service key in the
+configuration file (by default `/etc/glome/config`).

--- a/login/example.cfg
+++ b/login/example.cfg
@@ -1,6 +1,12 @@
 service
 {
-  key = 5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb
+  # Replace this with your own GLOME server-side public key.
+  #
+  # This can be generated as any other GLOME key, where the private key is
+  # given to the server (glome.example.com in this example) and the public key
+  # is distributed to all clients through this configuration file.
+  #
+  #key = 5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb
   key-version = 1
   url-prefix = "https://glome.example.com"
 }


### PR DESCRIPTION
Add an initial README and some guiding documentation in the example
config.

This also removes the example key from being installed, making it less
likely that a user accidentally installs the example key on a real
machine.

Fixes #34 and #26