### PR TITLE
Safer GLOME CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
           glome.c glome.h glome_test.c
     - name: check glome-cli format
       run: |
-        clang-format --Werror --dry-run --style=google cli/main.c
-
+        clang-format --Werror --dry-run --style=google \
+          cli/*.c cli/*.h
     - name: check glome-login format
       run: |
         clang-format --Werror --dry-run --style=google \

--- a/cli/commands.c
+++ b/cli/commands.c
@@ -1,0 +1,230 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "commands.h"
+
+#include <errno.h>
+#include <error.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <limits.h>
+#include <openssl/crypto.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "glome.h"
+
+#define GLOME_CLI_MAX_MESSAGE_LENGTH 4095
+
+// Arguments
+static const char *key_file = NULL;
+static const char *peer_file = NULL;
+static const char *tag_hex = NULL;
+static unsigned long counter = 0;
+
+static bool parse_args(int argc, char **argv) {
+  struct option long_options[] = {{"key", required_argument, 0, 'k'},
+                                  {"peer", required_argument, 0, 'p'},
+                                  {"counter", required_argument, 0, 'c'},
+                                  {"tag", required_argument, 0, 't'},
+                                  {0, 0, 0, 0}};
+
+  int c;
+  while ((c = getopt_long(argc, argv, "c:k:p:t:", long_options, NULL)) != -1) {
+    switch (c) {
+      case 'c': {
+        char *endptr;
+        counter = strtoul(optarg, &endptr, 0);
+        if (counter > UCHAR_MAX || optarg[0] == '\0' || *endptr != '\0') {
+          fprintf(stderr, "'%s' is not a valid counter (0..255)\n", optarg);
+          return false;
+        }
+        break;
+      }
+      case 'k':
+        key_file = optarg;
+        break;
+      case 'p':
+        peer_file = optarg;
+        break;
+      case 't':
+        tag_hex = optarg;
+        break;
+      case '?':
+        return false;
+      default:
+        // option not implemented
+        abort();
+    }
+  }
+  return true;
+}
+
+static int decode_hex(uint8_t *dst, size_t dst_len, const char *in) {
+  size_t len = strlen(in);
+  if (len > 2 && in[0] == '0' && in[1] == 'x') {
+    len -= 2;
+    in += 2;
+  }
+  if (len > dst_len * 2 || len % 2 != 0) {
+    return -1;
+  }
+  size_t i;
+  for (i = 0; i < len / 2; i++) {
+    if (sscanf(in + (i * 2), "%02hhX", dst + i) != 1) {
+      fprintf(stderr, "ERROR while parsing byte %zu ('%c%c') as hex\n", i,
+              in[2 * i], in[2 * i + 1]);
+      return -3;
+    }
+  }
+  return i;
+}
+
+static bool read_file(const char *fname, uint8_t *buf, const size_t num_bytes) {
+  FILE *f = fopen(fname, "r");
+  if (!f) {
+    fprintf(stderr, "could not open file %s: %s\n", fname, strerror(errno));
+    return false;
+  }
+  if (fread(buf, 1, num_bytes, f) != num_bytes) {
+    fprintf(stderr, "could not read %zu bytes from file %s", num_bytes, fname);
+    if (ferror(f)) {
+      fprintf(stderr, ": %s\n", strerror(errno));
+    } else {
+      fputs("\n", stderr);
+    }
+    fclose(f);
+    return false;
+  }
+  fclose(f);
+  return true;
+}
+
+static void print_hex(FILE *stream, const char *prefix, uint8_t *buf,
+                      size_t len) {
+  if (prefix != NULL) {
+    fputs(prefix, stream);
+  }
+  for (size_t i = 0; i < len; i++) {
+    fprintf(stream, "%02x", buf[i]);
+  }
+  fputs("\n", stream);
+}
+
+int genkey(int argc, char **argv) {
+  uint8_t private_key[GLOME_MAX_PRIVATE_KEY_LENGTH] = {0};
+
+  if (glome_generate_key(private_key, NULL)) {
+    fprintf(stderr, "unable to generate a new key\n");
+    return EXIT_FAILURE;
+  }
+  if (fwrite(private_key, 1, sizeof private_key, stdout) !=
+      sizeof private_key) {
+    perror("unable to write the private key to stdout");
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+int pubkey(int argc, char **argv) {
+  uint8_t private_key[GLOME_MAX_PRIVATE_KEY_LENGTH] = {0};
+  uint8_t public_key[GLOME_MAX_PUBLIC_KEY_LENGTH] = {0};
+
+  if (fread(private_key, 1, sizeof private_key, stdin) != sizeof private_key) {
+    perror("unable to read the private key from stdin");
+    return EXIT_FAILURE;
+  }
+  if (glome_derive_key(private_key, public_key)) {
+    fprintf(stderr, "unable to generate a new key\n");
+    return EXIT_FAILURE;
+  }
+  if (fwrite(public_key, 1, sizeof public_key, stdout) != sizeof public_key) {
+    perror("unable to write the public key to stdout");
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+// tag_impl reads a private key and a peer key from the given files and computes
+// a tag corresponding to a message read from stdin for the communication
+// direction determined by verify.
+int tag_impl(uint8_t tag[GLOME_MAX_TAG_LENGTH], bool verify,
+             const char *key_file, const char *peer_file) {
+  uint8_t private_key[GLOME_MAX_PRIVATE_KEY_LENGTH] = {0};
+  uint8_t peer_key[GLOME_MAX_PUBLIC_KEY_LENGTH] = {0};
+  char message[GLOME_CLI_MAX_MESSAGE_LENGTH] = {0};
+
+  if (!read_file(key_file, private_key, sizeof private_key) ||
+      !read_file(peer_file, peer_key, sizeof peer_key)) {
+    return EXIT_FAILURE;
+  };
+  size_t msg_len = fread(message, 1, GLOME_CLI_MAX_MESSAGE_LENGTH, stdin);
+  if (!feof(stdin)) {
+    fprintf(stderr, "message exceeds maximum supported size of %u",
+            GLOME_CLI_MAX_MESSAGE_LENGTH);
+    return EXIT_FAILURE;
+  }
+  if (glome_tag(verify, counter, private_key, peer_key, (uint8_t *)message,
+                msg_len, tag)) {
+    fputs("MAC tag generation failed", stderr);
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+int tag(int argc, char **argv) {
+  uint8_t tag[GLOME_MAX_TAG_LENGTH] = {0};
+  if (!parse_args(argc, argv)) {
+    return EXIT_FAILURE;
+  }
+  if (!key_file || !peer_file) {
+    fprintf(stderr, "not enough arguments for subcommand %s\n", argv[1]);
+    return EXIT_FAILURE;
+  }
+  int res = tag_impl(tag, /*verify=*/false, key_file, peer_file);
+  if (res) {
+    return res;
+  }
+  print_hex(stdout, "", tag, sizeof tag);
+  return EXIT_SUCCESS;
+}
+
+int verify(int argc, char **argv) {
+  uint8_t tag[GLOME_MAX_TAG_LENGTH] = {0};
+  uint8_t expected_tag[GLOME_MAX_TAG_LENGTH] = {0};
+  size_t expected_tag_len = 0;
+  if (!parse_args(argc, argv)) {
+    return EXIT_FAILURE;
+  }
+  if (!key_file || !peer_file || !tag_hex) {
+    fprintf(stderr, "not enough arguments for subcommand %s\n", argv[1]);
+    return EXIT_FAILURE;
+  }
+  int res = tag_impl(tag, /*verify=*/true, key_file, peer_file);
+  if (res) {
+    return res;
+  }
+
+  // compare the tag
+  expected_tag_len = decode_hex(expected_tag, sizeof expected_tag, tag_hex);
+  if (CRYPTO_memcmp(expected_tag, tag, expected_tag_len) != 0) {
+    fputs("MAC tag verification failed", stderr);
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/cli/commands.h
+++ b/cli/commands.h
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GLOME_CLI_COMMANDS_H
+#define GLOME_CLI_COMMANDS_H
+
+// Generates a new key and writes it to stdout.
+int genkey(int argc, char **argv);
+
+// Reads a private key from stdin and writes the corresponding public key to
+// stdout.
+int pubkey(int argc, char **argv);
+
+// Tags a message and writes it to stdout.
+int tag(int argc, char **argv);
+
+// Returns 0 iff the tag could be verified.
+int verify(int argc, char **argv);
+
+#endif  // GLOME_CLI_COMMANDS_H

--- a/cli/main.c
+++ b/cli/main.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <error.h>
 #include <fcntl.h>
+#include <getopt.h>
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -23,157 +24,55 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "commands.h"
 #include "glome.h"
 
-const char *kUsage =
+#define GLOME_CLI_MAX_MESSAGE_LENGTH 4095
+
+static const char *kUsage =
     "Usage: \n"
-    "  To generate a new keypair (PRIVATE-KEY will be created if needed)\n"
-    "    %s PRIVATE-KEY >PUBLIC-KEY\n\n"
-    "  To generate a tag (defaults: MESSAGE:='' counter:=0):\n"
-    "    %s PRIVATE-KEY PEER-KEY [MESSAGE [COUNTER]]\n\n"
+    "  To generate a new keypair\n"
+    "    umask 077\n"
+    "    %s genkey | tee PRIVATE-KEY-FILE | %s pubkey >PUBLIC-KEY-FILE\n\n"
+    "  To generate a tag:\n"
+    "    %s tag --key PRIVATE-KEY-FILE --peer PEER-KEY-FILE "
+    "[--counter COUNTER] <MESSAGE-FILE\n\n"
     "  To verify a tag:\n"
-    "    %s PRIVATE-KEY PEER-KEY MESSAGE COUNTER TAG\n";
+    "    %s verify --key PRIVATE-KEY-FILE --peer PEER-KEY-FILE --tag TAG "
+    "[--counter COUNTER] <MESSAGE-FILE\n";
 
-static int decode_hex(uint8_t *dst, size_t dst_len, const char *in) {
-  size_t len = strlen(in);
-  if (len > 2 && in[0] == '0' && in[1] == 'x') {
-    len -= 2;
-    in += 2;
-  }
-  if (len > dst_len * 2 || len % 2 != 0) {
-    return -1;
-  }
-  size_t i;
-  for (i = 0; i < len / 2; i++) {
-    if (sscanf(in + (i * 2), "%02hhX", dst + i) != 1) {
-      fprintf(stderr, "ERROR while parsing byte %zu ('%c%c') as hex\n", i,
-              in[2 * i], in[2 * i + 1]);
-      return -3;
-    }
-  }
-  return i;
+static int print_help(int argc, char **argv) {
+  fprintf(stderr, kUsage, argv[0], argv[0], argv[0], argv[0]);
+  return EXIT_SUCCESS;
 }
 
-int read_key(const char *fname, uint8_t *buf, const size_t buf_len) {
-  int fd = open(fname, O_RDONLY);
-  if (fd == -1) {
-    if (errno != ENOENT) {
-      return -1;
-    }
-    if (fname[0] != '\0' && fname[1] == '-' && fname[1] == '\0') {
-      // '-' means stdin
-      fd = STDIN_FILENO;
-    } else {
-      // Try parsing the provided filename as the key
-      return decode_hex(buf, buf_len, fname);
-    }
-  }
-  return read(fd, buf, buf_len);
-}
+typedef int (*mainfunc)(int argc, char **argv);
 
-void print_hex(FILE *stream, const char *prefix, uint8_t *buf, size_t len) {
-  if (prefix != NULL) {
-    fputs(prefix, stream);
-  }
-  for (size_t i = 0; i < len; i++) {
-    fprintf(stream, "%02x", buf[i]);
-  }
-  fputs("\n", stream);
-}
+struct cmd {
+  const char *name;
+  mainfunc run;
+};
+
+// cmds maps subcommand names to their implementation. The last entry with a
+// NULL name is executed when the subcommand given by the user is not found.
+static const struct cmd cmds[] = {
+    {"genkey", &genkey}, {"pubkey", &pubkey}, {"tag", &tag},
+    {"verify", &verify}, {NULL, &print_help},
+};
 
 int main(int argc, char **argv) {
-  uint8_t private_key[GLOME_MAX_PRIVATE_KEY_LENGTH] = {0};
-  uint8_t public_key[GLOME_MAX_PUBLIC_KEY_LENGTH] = {0};
-  uint8_t peer_key[GLOME_MAX_PUBLIC_KEY_LENGTH] = {0};
-  uint8_t tag[GLOME_MAX_TAG_LENGTH] = {0};
-  uint8_t expected_tag[GLOME_MAX_TAG_LENGTH] = {0};
-  size_t expected_tag_len = 0;
-  char *message = NULL;
-  char *endptr;
-  bool verification = false;
-  unsigned long counter = 0;
-
-  switch (argc) {
-    case 6:
-      expected_tag_len = read_key(argv[5], expected_tag, sizeof expected_tag);
-      if (expected_tag_len < 0) {
-        error(EXIT_FAILURE, errno, "unable to read the tag from %s", argv[5]);
-      }
-      verification = true;
-    case 5:
-      counter = strtoul(argv[4], &endptr, 0);
-      if (counter > UCHAR_MAX || argv[4][0] == '\0' || *endptr != '\0') {
-        error(EXIT_FAILURE, errno, "'%s' is not a valid counter (0..255)\n",
-              argv[4]);
-      }
-    case 4:
-      message = argv[3];
-    case 3:
-      if (read_key(argv[2], peer_key, sizeof peer_key) != sizeof peer_key) {
-        error(EXIT_FAILURE, errno, "unable to read the peer key from %s",
-              argv[2]);
-      }
-      print_hex(stderr, "peer-key:   0x", peer_key, sizeof peer_key);
-    case 2:
-      if (read_key(argv[1], private_key, sizeof private_key) !=
-          sizeof private_key) {
-        if (errno != ENOENT) {
-          error(EXIT_FAILURE, errno, "unable to read the private key from %s",
-                argv[1]);
-        }
-        int fd = open(argv[1], O_WRONLY | O_EXCL | O_CREAT, S_IRUSR | S_IWUSR);
-        if (fd == -1) {
-          error(EXIT_FAILURE, errno, "unable to create a new file at %s",
-                argv[1]);
-        }
-        if (glome_generate_key(private_key, public_key)) {
-          error(EXIT_FAILURE, 0, "unable to generate a new key pair");
-        }
-        if (write(fd, private_key, sizeof private_key) != sizeof private_key) {
-          error(EXIT_FAILURE, errno, "unable to write the private key to %s",
-                argv[1]);
-        }
-        close(fd);
-      }
-      break;
-    default:
-      error(EXIT_FAILURE, 0, kUsage, argv[0], argv[0], argv[0]);
+  if (argc == 0) {
+    fputs("called with empty argv\n", stderr);
+    return EXIT_FAILURE;
   }
-
-  if (glome_derive_key(private_key, public_key)) {
-    error(EXIT_FAILURE, 0, "unable to derive public key");
+  if (argc < 2) {
+    return print_help(argc, argv);
   }
-
-  if (argc == 2) {  // key generation
-    if (isatty(STDOUT_FILENO) == 1) {
-      print_hex(stdout, NULL, public_key, sizeof public_key);
-    } else {
-      write(STDOUT_FILENO, public_key, sizeof public_key);
-    }
-    return EXIT_SUCCESS;
+  // Traverse the known subcommands until the requested subcommand is found, or
+  // until we hit the catch-all without a name.
+  const struct cmd *c = cmds;
+  while (c->name && strcmp(c->name, argv[1])) {
+    c++;
   }
-
-  // Debug information
-  print_hex(stderr, "public-key: 0x", public_key, sizeof public_key);
-  fprintf(stderr, "message:   '%s'\n", message == NULL ? "" : message);
-  fprintf(stderr, "counter:    %ld\n", counter);
-  fprintf(stderr, "verify:     %d\n", verification);
-
-  if (glome_tag(verification, counter, private_key, peer_key,
-                (uint8_t *)message, message == NULL ? 0 : strlen(message),
-                tag)) {
-    error(EXIT_FAILURE, 0, "MAC tag generation failed");
-  }
-
-  if (argc == 6) {  // tag verification
-    print_hex(stderr, "mac-tag:    0x", tag, sizeof tag);
-    print_hex(stderr, "unverified: 0x", expected_tag, expected_tag_len);
-    if (memcmp(expected_tag, tag, expected_tag_len) != 0) {
-      error(EXIT_FAILURE, 0, "MAC tag verfication failed");
-    }
-  } else {  // tag generation
-    print_hex(stdout, NULL, tag, sizeof tag);
-  }
-
-  return EXIT_SUCCESS;
+  return c->run(argc, argv);
 }

--- a/cli/meson.build
+++ b/cli/meson.build
@@ -12,8 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-glome_cli = executable('glome', 'main.c', link_with : glome_lib,
-  include_directories : glome_incdir, install : true)
+openssl_dep = dependency('openssl', version : '>=1.1')
+
+glome_cli = executable(
+  'glome',
+  [
+    'main.c',
+    'commands.h',
+    'commands.c',
+  ],
+  dependencies: openssl_dep,
+  link_with : glome_lib,
+  include_directories : glome_incdir,
+  install : true)
 
 cli_test = find_program('test.sh')
 test('cli', cli_test,


### PR DESCRIPTION
This PR reworks the invocation of the `glome` utility to make it unambiguous in its arguments and overall safer to use correctly.

* private key and peer key are now always expected to be files
* arguments are passed as flags so that they cannot be passed in the wrong order accidentally
* messages (which may have sensitive content) are passed via `stdin` to reduce possibility of leaks
* the code is restructured to separate `main` concerns from the functionality