### PR TITLE
Consistent login_config

### DIFF
--- a/login/config.c
+++ b/login/config.c
@@ -44,12 +44,12 @@ int parse_config_file(login_config_t* config) {
   cfg_t* cfg = cfg_init(opts, CFGF_NONE);
   cfg_set_error_function(cfg, print_config_error);
 
-  int required = config->config_file != NULL;
+  int required = config->config_path != NULL;
   if (!required) {
-    config->config_file = DEFAULT_CONFIG_FILE;
+    config->config_path = DEFAULT_CONFIG_FILE;
   }
 
-  int r = cfg_parse(cfg, config->config_file);
+  int r = cfg_parse(cfg, config->config_path);
   if (required && r == CFG_FILE_ERROR) {
     perror("ERROR: config file could not be read");
     cfg_free(cfg);

--- a/login/ui.c
+++ b/login/ui.c
@@ -108,7 +108,7 @@ int parse_args(login_config_t* config, int argc, char* argv[]) {
     long l;
     switch (c) {
       case 'c':
-        config->config_file = optarg;
+        config->config_path = optarg;
         break;
       case 'd':
         errno = 0;

--- a/login/ui.h
+++ b/login/ui.h
@@ -52,7 +52,7 @@ typedef struct login_config {
   char* username;
 
   // Configuration file to parse.
-  const char* config_file;
+  const char* config_path;
 
   // Login binary for fallback authentication.
   const char* login_path;


### PR DESCRIPTION
PR fixes some inconsistency in login_config fields naming, namely between files/pathes. 