### PR TITLE
KeyFetcher signature to use ptr

### DIFF
--- a/go/login/login_test.go
+++ b/go/login/login_test.go
@@ -140,8 +140,8 @@ func clientsAndServers(t *testing.T, tvs []testVector) ([]Client, []Server) {
 		clients = append(clients, *NewClient(keyPairs[tv][1].pub, keyPairs[tv][0].priv, serviceKeyIDs[tv], clientTagsLen[tv]))
 		sPrivKey := keyPairs[tv][1].priv
 		servers = append(servers,
-			Server{func(u uint8) (glome.PrivateKey, error) {
-				return sPrivKey, nil
+			Server{func(u uint8) (*glome.PrivateKey, error) {
+				return &sPrivKey, nil
 			}})
 	}
 	return clients, servers

--- a/go/login/server/keymanager.go
+++ b/go/login/server/keymanager.go
@@ -41,16 +41,6 @@ func (e ErrDuplicatedKeyIndex) Error() string {
 	return fmt.Sprintf("key index already in use, found: %v", e.Index)
 }
 
-// ErrKeyIndexNotFound denotes that an index was not found, so no key can be
-// returned from it.
-type ErrKeyIndexNotFound struct {
-	Index uint8
-}
-
-func (e ErrKeyIndexNotFound) Error() string {
-	return fmt.Sprintf("key index %v not found", e.Index)
-}
-
 // A PrivateKey represent a Private key for the login server. It is a pair composed of a private key
 // and its pairing index.
 type PrivateKey struct {
@@ -137,20 +127,20 @@ func (k *KeyManager) ServiceKeys() []PublicKey {
 }
 
 // Return a function that implements key fetching. The function
-// returns ErrInvalidKeyIndex if index is not in {0,...,127}, and ErrIndexNotFound
+// returns ErrInvalidKeyIndex if index is not in {0,...,127}, and nil
 // if the provided index does not match any key.
-func (k *KeyManager) keyFetcher() func(uint8) (glome.PrivateKey, error) {
-	return func(index uint8) (glome.PrivateKey, error) {
+func (k *KeyManager) keyFetcher() func(uint8) (*glome.PrivateKey, error) {
+	return func(index uint8) (*glome.PrivateKey, error) {
 		if index > 127 {
-			return glome.PrivateKey{}, ErrInvalidKeyIndex{Index: index}
+			return nil, ErrInvalidKeyIndex{Index: index}
 		}
 
 		key, found := k.Read(index)
 		if !found {
-			return glome.PrivateKey{}, ErrKeyIndexNotFound{Index: index}
+			return nil, nil
 		}
 
-		return key, nil
+		return &key, nil
 	}
 }
 


### PR DESCRIPTION
This improves the impedance between the glome.PrivateKey object and
helper functions and login.Server's KeyFetcher. This makes the error
case and using the helper functions smoother.