### PR TITLE
pyglome: ship unit tests in sdist

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,2 +1,7 @@
 *__pycache__*
 *~
+
+# setuptools outputs
+build
+dist
+*.egg-info

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include test *


### PR DESCRIPTION
The current sdist archive on PyPI is lacking unit tests files. setuptools tries to include them by default, but it only adds test*.py files, and pyglome unit tests do not follow this naming convention.

Before:
```
pyglome-0.0.2/
pyglome-0.0.2/README.md
pyglome-0.0.2/test/
pyglome-0.0.2/test/test_vectors.py
pyglome-0.0.2/PKG-INFO
pyglome-0.0.2/pyglome.egg-info/
pyglome-0.0.2/pyglome.egg-info/top_level.txt
pyglome-0.0.2/pyglome.egg-info/PKG-INFO
pyglome-0.0.2/pyglome.egg-info/dependency_links.txt
pyglome-0.0.2/pyglome.egg-info/SOURCES.txt
pyglome-0.0.2/pyglome.egg-info/requires.txt
pyglome-0.0.2/setup.cfg
pyglome-0.0.2/pyglome/
pyglome-0.0.2/pyglome/glome.py
pyglome-0.0.2/pyglome/__init__.py
pyglome-0.0.2/setup.py
```

After:
```
pyglome-0.0.2/
pyglome-0.0.2/MANIFEST.in
pyglome-0.0.2/PKG-INFO
pyglome-0.0.2/README.md
pyglome-0.0.2/pyglome/
pyglome-0.0.2/pyglome/__init__.py
pyglome-0.0.2/pyglome/glome.py
pyglome-0.0.2/pyglome.egg-info/
pyglome-0.0.2/pyglome.egg-info/PKG-INFO
pyglome-0.0.2/pyglome.egg-info/SOURCES.txt
pyglome-0.0.2/pyglome.egg-info/dependency_links.txt
pyglome-0.0.2/pyglome.egg-info/requires.txt
pyglome-0.0.2/pyglome.egg-info/top_level.txt
pyglome-0.0.2/setup.cfg
pyglome-0.0.2/setup.py
pyglome-0.0.2/test/
pyglome-0.0.2/test/__init__.py
pyglome-0.0.2/test/__main__.py
pyglome-0.0.2/test/autoglome_test.py
pyglome-0.0.2/test/fuzzing_test.py
pyglome-0.0.2/test/glome_test.py
pyglome-0.0.2/test/test_vectors.py
```

(Also included a .gitignore change, I hope you don't mind.)