### PR TITLE
Apply clang-format to all C source files.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,21 +58,10 @@ jobs:
         export DEBIAN_FRONTEND=noninteractive
         apt-get update
         apt-get install -y clang-format
-    - name: check libglome format
+    - name: check format
       run: |
-        clang-format --Werror --dry-run --style=google \
-          glome.c glome.h glome_test.c
-    - name: check glome-cli format
-      run: |
-        clang-format --Werror --dry-run --style=google \
-          cli/*.c cli/*.h
-    - name: check glome-login format
-      run: |
-        clang-format --Werror --dry-run --style=google \
-          login/config.c login/crypto.c login/crypto_test.c login/lockdown.c \
-          login/login.c login/login_test.c login/main.c login/ui.c \
-          login/base64.h login/config.h login/crypto.h login/lockdown.h \
-          login/login.h login/ui.h
+        find . -name "*.c" -or -name "*.h" | \
+          xargs clang-format --Werror --dry-run --style=google
 
   python_presubmit:
     runs-on: ubuntu-18.04

--- a/login/openssl/base64.c
+++ b/login/openssl/base64.c
@@ -26,7 +26,7 @@ size_t base64url_encode(const uint8_t* src, size_t src_len, uint8_t* dst,
   size_t len = ENCODED_BUFSIZE(src_len);
   // The ENCODED_BUFSIZE macro has not been tested for operation close
   // to the overflow point, but up to SIZE_MAX/2 it behaves fine.
-  if (src_len >= SIZE_MAX/2) {
+  if (src_len >= SIZE_MAX / 2) {
     return 0;
   }
   if (len > dst_len) {


### PR DESCRIPTION
The amount of source files keeps growing and it's easy to forget to add
them to the integration test script (case in point, happened to the pam
files). Since we do not include any third-party sources, the easiest
thing is to check all .c and .h files.