### PR TITLE
Fix the format specifier of service_key_version

### DIFF
--- a/login/config.c
+++ b/login/config.c
@@ -50,7 +50,8 @@ int parse_config_file(login_config_t* config) {
   service_key_version =
       g_key_file_get_uint64(cfg, "service", "key-version", NULL);
   if (service_key_version > 255) {
-    errorf("ERROR: Key version %llu too large, must fit into 8-bit int\n",
+    errorf("ERROR: Key version %" G_GUINT64_FORMAT " too large, must fit into ",
+           "8-bit int\n",
            service_key_version);
     return -3;
   }

--- a/login/config.c
+++ b/login/config.c
@@ -50,7 +50,7 @@ int parse_config_file(login_config_t* config) {
   service_key_version =
       g_key_file_get_uint64(cfg, "service", "key-version", NULL);
   if (service_key_version > 255) {
-    errorf("ERROR: Key version %ld too large, must fit into 8-bit int\n",
+    errorf("ERROR: Key version %llu too large, must fit into 8-bit int\n",
            service_key_version);
     return -3;
   }

--- a/login/config.c
+++ b/login/config.c
@@ -50,8 +50,8 @@ int parse_config_file(login_config_t* config) {
   service_key_version =
       g_key_file_get_uint64(cfg, "service", "key-version", NULL);
   if (service_key_version > 255) {
-    errorf("ERROR: Key version %" G_GUINT64_FORMAT " too large, must fit into ",
-           "8-bit int\n",
+    errorf("ERROR: Key version %" G_GUINT64_FORMAT
+           " too large, must fit into 8-bit int\n",
            service_key_version);
     return -3;
   }


### PR DESCRIPTION
Address the warning about the mismatched format specifier:

```c
$ ninja -C build
ninja: Entering directory `build'
[1/6] Compiling C object 'login/4288213@@glome-login@sta/config.c.o'.
In file included from ../login/config.c:19:
../login/config.c: In function ‘parse_config_file’:
../login/config.c:53:12: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘guint64’ {aka ‘long long unsigned int’} [-Wformat=]
     errorf("ERROR: Key version %ld too large, must fit into 8-bit int\n",
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            service_key_version);
            ~~~~~~~~~~~~~~~~~~~
../login/ui.h:23:37: note: in definition of macro ‘errorf’
 #define errorf(...) fprintf(stderr, __VA_ARGS__)
```