### PR TITLE
PAM: Check the authcode against the authtok

### DIFF
--- a/login/pam_test.c
+++ b/login/pam_test.c
@@ -28,7 +28,7 @@ const char *authtoks[] = {
 };
 
 struct pamtest_conv_data conv_data = {
-    .in_echo_on = authtoks,
+    .in_echo_off = authtoks,
 };
 
 struct pam_testcase tests[] = {


### PR DESCRIPTION
Print the link to GLOME's login server through the conversational
interface (PAM_TEXT_INFO) and then check the authcode against the
(possibly cached) authtok. This allows proper chaining of PAM modules,
including password fallback through pam_unix. (#91)

Behavior change: This no longer prints the authcode while typing,
as it reuses the regular (echo off) password prompt.