### PR TITLE
Remove unneccessary username limit.

### DIFF
--- a/login/main.c
+++ b/login/main.c
@@ -48,12 +48,6 @@ int main(int argc, char* argv[]) {
     return EXITCODE_PANIC;
   }
 
-  r = postprocess_config(&config);
-  if (r < 0) {
-    handle_error("postprocess-config");
-    return EXITCODE_PANIC;
-  }
-
   const char* error_tag = NULL;
   int rc = login_run(&config, &error_tag);
   if (rc) {

--- a/login/pam.c
+++ b/login/pam.c
@@ -241,12 +241,6 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
     return rc;
   }
 
-  r = postprocess_config(&config);
-  if (r < 0) {
-    pam_syslog(pamh, LOG_ERR, "failed to postprocess config (%d)", r);
-    return rc;
-  }
-
   r = glome_authenticate(pamh, &config, &error_tag, argc, argv);
   if (!r) {
     rc = PAM_SUCCESS;

--- a/login/ui.c
+++ b/login/ui.c
@@ -185,13 +185,6 @@ int parse_args(login_config_t* config, int argc, char* argv[]) {
   return 0;
 }
 
-int postprocess_config(login_config_t* config) {
-  if (strlen(config->username) > USERNAME_MAX) {
-    return -1;
-  }
-  return 0;
-}
-
 int read_stdin(char* buf, size_t buflen) {
   int i = 0;
 

--- a/login/ui.h
+++ b/login/ui.h
@@ -22,8 +22,6 @@
 
 #define errorf(...) fprintf(stderr, __VA_ARGS__)
 
-#define USERNAME_MAX 32
-
 #if !defined(SYSCONFDIR)
 #define SYSCONFDIR "/etc"
 #endif
@@ -85,10 +83,6 @@ int decode_hex(uint8_t* dst, size_t dst_len, const char* in);
 // parse_args parses command-line arguments into a config struct. It will
 // forcefully initialize the whole content of the struct to zero.
 int parse_args(login_config_t* config, int argc, char* argv[]);
-
-// postprocess_config updates the configuration based on implied configuration
-// in the input.
-int postprocess_config(login_config_t* config);
 
 // read_stdin reads printable characters from stdin into buf. It returns:
 // -1, if it encounters an error while reading


### PR DESCRIPTION
The username is passed to shell_action(), which allocates a buffer
dynamically and does not depend on the username being a particular size.

As a side-effect, this simplifies config processing by removing the
config validation step.