### PR TITLE
login: Remove glib dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Building the GLOME library requires
  - Compiler conforming to C99 (e.g. gcc, clang)
  - Meson >=0.49.2
  - OpenSSL headers >=1.1.1
- - glib-2.0 (for glome-login as well as tests)
+ - iniparser (for glome-login)
+ - glib-2.0 (for tests)
  - libpam (for PAM module)
 
 ### Instructions

--- a/login/meson.build
+++ b/login/meson.build
@@ -17,6 +17,8 @@ install_data(
   rename : 'config',
   install_dir : join_paths(get_option('sysconfdir'), 'glome'))
 
+iniparser_dep = meson.get_compiler('c').find_library('iniparser')
+
 login_lib = static_library(
     'glome-login',
     [
@@ -30,7 +32,7 @@ login_lib = static_library(
         'ui.c',
         'ui.h',
     ],
-    dependencies : [openssl_dep, glib_dep],
+    dependencies : [openssl_dep, iniparser_dep],
     link_with : glome_lib,
     include_directories : glome_incdir,
     install : false)


### PR DESCRIPTION
For embedded linux systems this is a heavy dependency that we would like
to avoid. We only use a small portion of glib that can be trivially
replaced by a simple ini parser and escape function.

Tested:
    Unit tests still pass for URL encoding and the config file was
    loaded on a system with an existing glome-login installation.