### PR TITLE
Create a Docker container for testing glome-login

### DIFF
--- a/cli/commands.c
+++ b/cli/commands.c
@@ -370,7 +370,7 @@ int login(int argc, char **argv) {
     return EXIT_FAILURE;
   }
 
-  char *path = argv[optind];
+  char *path = strstr(argv[optind], "/v1/");
   if (!parse_login_path(path, &handshake_b64, &host_esc, &action)) {
     return EXIT_FAILURE;
   }

--- a/kokoro/docker/Dockerfile
+++ b/kokoro/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM docker.io/library/debian:bullseye AS build
+WORKDIR /app
+COPY . .
+RUN kokoro/rodete/fetch_dependencies.sh
+RUN rm -rf build \
+    && meson build \
+    && meson compile -C build \
+    && meson test --print-errorlogs -C build \
+    && meson install -C build
+
+FROM docker.io/library/debian:bullseye
+COPY --from=build /usr/local /usr/local
+COPY kokoro/docker/glome-start /usr/local/sbin
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+       openssh-server \
+       socat \
+       xxd \
+    && rm -rf /var/lib/apt/lists/*
+CMD ["/usr/local/sbin/glome-start"]
+EXPOSE 22 23

--- a/kokoro/docker/glome-start
+++ b/kokoro/docker/glome-start
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+GLOME=/usr/local/bin/glome
+GLOME_LOGIN=/usr/local/sbin/glome-login
+CONFIG=/usr/local/etc/glome/config
+PRIVATE=/usr/local/etc/glome/private.key
+PUBLIC=/usr/local/etc/glome/public.key
+
+umask 077
+$GLOME genkey | tee $PRIVATE | $GLOME pubkey > $PUBLIC
+
+PUBLIC_HEX=$(xxd -c 32 -ps $PUBLIC)
+sed -i "s/^#key = .*/key = $PUBLIC_HEX/" $CONFIG
+sed -i "1 i\auth sufficient /usr/local/lib/x86_64-linux-gnu/security/pam_glome.so" /etc/pam.d/sshd
+cat <<EOF > /etc/ssh/sshd_config.d/glome.conf
+ChallengeResponseAuthentication yes
+PermitRootLogin yes
+EOF
+
+mkdir /run/sshd
+/usr/sbin/sshd
+
+socat tcp-l:23,reuseaddr,fork exec:"/sbin/agetty -l $GLOME_LOGIN -",pty,setsid,setpgid,stderr,ctty

--- a/kokoro/rodete/fetch_dependencies.sh
+++ b/kokoro/rodete/fetch_dependencies.sh
@@ -3,6 +3,6 @@ set -e
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y \
+apt-get install -y --no-install-recommends \
   build-essential meson pkg-config \
   libssl-dev libglib2.0-dev libpam0g-dev libpam-wrapper

--- a/login/README.md
+++ b/login/README.md
@@ -92,3 +92,44 @@ PAM module supports the following options:
 ## Troubleshooting
 
 PAM module uses error tags to communicate errors in the syslog messages.
+
+# Docker
+
+Dockerfile included in the repository creates a Docker image that can be used
+to test `glome-login` and the PAM module.
+
+## Instalation
+
+Docker image for GLOME needs to be built first using the following command:
+
+```
+$ docker build -t glome -f kokoro/docker/Dockerfile .
+```
+
+## Usage
+
+Container is than started in the background with two TCP ports published to the
+host:
+
+```
+$ container=$(docker run -d -p 2022:22 -p 2023:23 glome)
+```
+
+Once the container is running it is possible to login using `netcat` or
+`socat`, for example:
+
+```
+$ socat tcp-connect:localhost:2023 file:`tty`,raw,echo=0
+```
+
+Regular SSH client can be used for testing the PAM module:
+
+```
+$ ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2022 root@localhost
+```
+
+Authorization code required for GLOME Login can be obtained by running:
+
+```
+$ docker exec $container /usr/local/bin/glome login --key /usr/local/etc/glome/private.key https://glome.example.com/v1/...
+```


### PR DESCRIPTION
Build and start the container using:

    $ docker build -t glome -f kokoro/docker/Dockerfile .
    $ docker run -d -p 2023:2023 glome

Connect to the container using netcat or socat, for example:

    $ socat tcp-connect:localhost:2023 file:`tty`,raw,echo=0

Get the authorization code by running:

    $ docker exec b4b6e14f1d2c /usr/local/bin/glome login --key /usr/local/etc/glome/private.key http://...