### PR TITLE
Support compilation with both old and new pam_wrapper

### DIFF
--- a/login/meson.build
+++ b/login/meson.build
@@ -76,9 +76,15 @@ if get_option('pam-glome')
     if get_option('tests')
         libpamtest = dependency('libpamtest', required : false)
         if libpamtest.found()
+            oldstyle_run_pamtest = cc.compiles('''#include <stddef.h>
+            #include <libpamtest.h>
+            void test() { run_pamtest(NULL, NULL, NULL, NULL); }
+            ''',
+                dependencies : [libpamtest])
             pam_test = executable(
                 'pam_test', 'pam_test.c',
-                dependencies : [libpamtest])
+                dependencies : [libpamtest],
+                c_args : oldstyle_run_pamtest ? '-DOLDSTYLE_RUN_PAMTEST' : '')
             custom_target('pam_service',
                 build_by_default : true, output : [ 'pam_service' ],
                 command : [ 'mkdir', '@OUTPUT@' ])

--- a/login/pam_test.c
+++ b/login/pam_test.c
@@ -85,7 +85,11 @@ int test_service() {
           pam_glome);
   fclose(f);
 
+#if defined(OLDSTYLE_RUN_PAMTEST)
   perr = run_pamtest(service, username, &conv_data, tests);
+#else
+  perr = run_pamtest(service, username, &conv_data, tests, NULL);
+#endif
   if (perr != PAMTEST_ERR_OK) {
     puts(pamtest_strerror(perr));
     return 1;
@@ -163,7 +167,12 @@ int test_config() {
   fclose(f);
   free(config_file);
 
+#if defined(OLDSTYLE_RUN_PAMTEST)
   perr = run_pamtest(service, username, &conv_data, tests);
+#else
+  perr = run_pamtest(service, username, &conv_data, tests, NULL);
+#endif
+
   if (perr != PAMTEST_ERR_OK) {
     puts(pamtest_strerror(perr));
     return 1;


### PR DESCRIPTION
pam_wrapper changed the signature of run_pamtest to allow for five
arguments - to enable reusing an existing pam_handle. However this
breaks the API in a hard to check for way. The pkg-config file also does
not specify a version. So this tests if compilation with the old
macro signature succeeds and if so conditionally uses the old syntax in
the code.