### PR TITLE
Run the C compilation presubmit on Debian stable and testing

### DIFF
--- a/.github/workflows/presubmit-c.yml
+++ b/.github/workflows/presubmit-c.yml
@@ -19,14 +19,15 @@ jobs:
     strategy:
       matrix:
         container:
-        - 'debian:latest'
+        - 'debian:stable'
+        - 'debian:testing'
         - 'alpine:latest'
     container:
       image: ${{ matrix.container }}
     steps:
     - uses: actions/checkout@v2
     - name: install Debian dependencies
-      if: ${{ matrix.container == 'debian:latest' }}
+      if: ${{ startsWith(matrix.container, 'debian:') }}
       run: ./kokoro/rodete/fetch_dependencies.sh
     - name: install Alpine dependencies
       if: ${{ matrix.container == 'alpine:latest' }}


### PR DESCRIPTION
We saw breakage on internal presubmits against Debian testing.
debian:latest points to the latest Debian stable. Let's make that
part explicit.

This change depends on #123 being merged first to fix
compatibility with Debian testing.