### PR TITLE
pam_glome: support fake passwords from OpenSSH

### DIFF
--- a/login/pam.c
+++ b/login/pam.c
@@ -168,7 +168,8 @@ int login_prompt(glome_login_config_t *config, pam_handle_t *pamh,
   // OpenSSH provides fake password when login is not allowed,
   // for example due to PermitRootLogin set to 'no'
   // https://github.com/openssh/openssh-portable/commit/283b97
-  const char fake_password[] = "\b\n\r\177INCORRECT"; // auth-pam.c from OpenSSH
+  const char fake_password[] =
+      "\b\n\r\177INCORRECT";  // auth-pam.c from OpenSSH
   bool is_fake = true;
 
   // Constant-time comparison in case token contains user's password

--- a/login/pam.c
+++ b/login/pam.c
@@ -164,6 +164,22 @@ int login_prompt(glome_login_config_t *config, pam_handle_t *pamh,
   if (strlen(token) >= input_size) {
     return failure(EXITCODE_PANIC, error_tag, "pam-authtok-size");
   }
+
+  // OpenSSH provides fake password when login is not allowed,
+  // for example due to PermitRootLogin set to 'no'
+  // https://github.com/openssh/openssh-portable/commit/283b97
+  const char fake_password[] = "\b\n\r\177INCORRECT";  // auth-pam.c from OpenSSH
+  bool is_fake = true;
+
+  // Constant-time comparison in case token contains user's password
+  for (size_t i = 0; i < strlen(token); i++) {
+    is_fake &= (token[i] == fake_password[i % (sizeof(fake_password) - 1)]);
+  }
+  if (is_fake) {
+    pam_syslog(pamh, LOG_ERR, "login disallowed by OpenSSH (PermitRootLogin?)");
+    return EXITCODE_PANIC;
+  }
+
   strncpy(input, token, input_size);
   return 0;
 }

--- a/login/pam.c
+++ b/login/pam.c
@@ -177,8 +177,7 @@ int login_prompt(glome_login_config_t *config, pam_handle_t *pamh,
     is_fake &= (token[i] == fake_password[i % (sizeof(fake_password) - 1)]);
   }
   if (is_fake) {
-    pam_syslog(pamh, LOG_ERR, "login disallowed by OpenSSH (PermitRootLogin?)");
-    return EXITCODE_PANIC;
+    return failure(EXITCODE_PANIC, error_tag, "pam-authtok-openssh-no-login");
   }
 
   strncpy(input, token, input_size);

--- a/login/pam.c
+++ b/login/pam.c
@@ -168,7 +168,7 @@ int login_prompt(glome_login_config_t *config, pam_handle_t *pamh,
   // OpenSSH provides fake password when login is not allowed,
   // for example due to PermitRootLogin set to 'no'
   // https://github.com/openssh/openssh-portable/commit/283b97
-  const char fake_password[] = "\b\n\r\177INCORRECT";  // auth-pam.c from OpenSSH
+  const char fake_password[] = "\b\n\r\177INCORRECT"; // auth-pam.c from OpenSSH
   bool is_fake = true;
 
   // Constant-time comparison in case token contains user's password

--- a/login/pam_test.c
+++ b/login/pam_test.c
@@ -21,14 +21,12 @@
 #include <libpamtest.h>
 
 const char *authtoks[] = {
-    "lyHuaHuCck",           /* Correct code */
-    "lyHuaHuCc",            /* Too short */
-    "INVALIDCODE",          /* Wrong code */
+    "lyHuaHuCck",  /* Correct code */
+    "lyHuaHuCc",   /* Too short */
+    "INVALIDCODE", /* Wrong code */
     /* fake passwords that might be provided by openssh-portable/auth-pam.c */
-    "\b\n\r\177",
-    "\b\n\r\177INCORRECT",
-    "\b\n\r\177INCORRECT\b\n\r\177",
-    NULL                    /* Terminator */
+    "\b\n\r\177", "\b\n\r\177INCORRECT", "\b\n\r\177INCORRECT\b\n\r\177",
+    NULL /* Terminator */
 };
 
 struct pamtest_conv_data conv_data = {

--- a/login/pam_test.c
+++ b/login/pam_test.c
@@ -21,10 +21,14 @@
 #include <libpamtest.h>
 
 const char *authtoks[] = {
-    "lyHuaHuCck",  /* Correct code */
-    "lyHuaHuCc",   /* Too short */
-    "INVALIDCODE", /* Wrong code */
-    NULL           /* Terminator */
+    "lyHuaHuCck",           /* Correct code */
+    "lyHuaHuCc",            /* Too short */
+    "INVALIDCODE",          /* Wrong code */
+    /* fake passwords that might be provided by openssh-portable/auth-pam.c */
+    "\b\n\r\177",
+    "\b\n\r\177INCORRECT",
+    "\b\n\r\177INCORRECT\b\n\r\177",
+    NULL                    /* Terminator */
 };
 
 struct pamtest_conv_data conv_data = {
@@ -33,6 +37,9 @@ struct pamtest_conv_data conv_data = {
 
 struct pam_testcase tests[] = {
     pam_test(PAMTEST_AUTHENTICATE, PAM_SUCCESS),
+    pam_test(PAMTEST_AUTHENTICATE, PAM_AUTH_ERR),
+    pam_test(PAMTEST_AUTHENTICATE, PAM_AUTH_ERR),
+    pam_test(PAMTEST_AUTHENTICATE, PAM_AUTH_ERR),
     pam_test(PAMTEST_AUTHENTICATE, PAM_AUTH_ERR),
     pam_test(PAMTEST_AUTHENTICATE, PAM_AUTH_ERR),
 };


### PR DESCRIPTION
OpenSSH provides PAM modules with a fake passwords when it is not going to permit the user to log in (e.g., due to PermitRootLogin=no), as per https://github.com/openssh/openssh-portable/commit/283b97ff33ea2c64116

Let `pam_glome` spare users debugging why valid authcodes are being rejected, by hinting at OpenSSH.