### PR TITLE
Sync PAM config options names with the rest of the code.

### DIFF
--- a/login/README.md
+++ b/login/README.md
@@ -77,16 +77,16 @@ PAM module supports the following options:
 
 * `config_path=PATH` - location of the configuration file to parse (defaults to
   `/etc/glome/config`)
-* `service_key=KEY` - use hex-encoded `KEY` as the service key (defaults to key
+* `key=KEY` - use hex-encoded `KEY` as the service key (defaults to key
   from configuration file)
-* `service_key_version=N` - use `N` for the service key version (defaults to key
+* `key_version=N` - use `N` for the service key version (defaults to key
   version from configuration file)
 * `url_prefix=URL` - use given URL prefix (defaults to prefix from configuration
   file)
 * `debug` - enable verbose logging
-* `insecure_debug` - enable logging of secrets (INSECURE!)
-* `insecure_host_id=NAME` - use `NAME` as the host-id
-* `insecure_secret_key=KEY` - use hex-encoded `KEY` instead of the ephemeral
+* `print_secrets` - enable logging of secrets (INSECURE!)
+* `host_id=NAME` - use `NAME` as the host-id
+* `ephemeral_key=KEY` - use hex-encoded `KEY` instead of the ephemeral
   secret key (INSECURE!)
 
 ## Troubleshooting

--- a/login/pam_test.c
+++ b/login/pam_test.c
@@ -81,12 +81,12 @@ int test_service() {
 
   fprintf(f,
           "auth required %s url_prefix=https://test.service "
-          "service_key="
+          "key="
           "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f "
-          "service_key_version=1 "
-          "insecure_secret_key="
+          "key_version=1 "
+          "ephemeral_key="
           "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a "
-          "insecure_host_id=my-server.local",
+          "host_id=my-server.local",
           pam_glome);
   fclose(f);
 
@@ -165,9 +165,9 @@ int test_config() {
 
   fprintf(f,
           "auth required %s config_path=%s "
-          "insecure_secret_key="
+          "ephemeral-key="
           "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a "
-          "insecure_host_id=my-server.local",
+          "host-id=my-server.local",
           pam_glome, config_file);
   fclose(f);
   free(config_file);


### PR DESCRIPTION
Use the same parameter names as in the config file and long command line
options but allow underscore instead of dash.

Fixes #127.