### PR TITLE
Clarify public key format and add tests

### DIFF
--- a/docs/rfd/002.md
+++ b/docs/rfd/002.md
@@ -24,9 +24,9 @@ See also [google/glome#100](https://github.com/google/glome/issues/100).
 
 # Design ideas
 
-Public keys are stored in base64 encoding and tagged with their protocol
-variant. The configuration file format accepts keys in a format similar to
-[OpenSSH's `authorized_keys` format][1].
+Public keys are stored in URL-safe base64 encoding and tagged with their
+protocol variant version. The configuration file format accepts keys in a
+format similar to [OpenSSH's `authorized_keys` format][1].
 
 [1]: https://man.openbsd.org/sshd.8#AUTHORIZED_KEYS_FILE_FORMAT
 
@@ -37,8 +37,8 @@ The format of a _GLOME public key_ adheres to the ABNF below:
 ```abnf
 public-key = key-type SP key-base64
 key-type = "glome-v1"
-key-base64 = 44base64-char
-base64-char = "=" / "+" / "/" / ALPHA / DIGIT
+key-base64 = 44urlsafe-base64-char
+urlsafe-base64-char = "=" / "-" / "_" / ALPHA / DIGIT
 ```
 
 The key type encodes the GLOME variant this key should be used with. As we
@@ -47,7 +47,7 @@ only have one variant right now, we're only defining one `key-type` here.
 An example public key, like it would be printed by `glome pubkey`:
 
 ```
-glome-v1 lXmlq5jynG6um/w4D4N13TRIE+x7jt0TKVNDMSRS2/I=
+glome-v1 lXmlq5jynG6um_w4D4N13TRIE-x7jt0TKVNDMSRS2_I=
 ```
 
 ## Public Key Interpretation

--- a/login/config_test.c
+++ b/login/config_test.c
@@ -1,0 +1,54 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "config.h"
+
+#include <stdio.h>
+
+#include <glib.h>
+
+static const char* ENCODED_PUBLIC_KEY = "glome-v1 aqA9yqe1RXoOT6HrmCbF40wVUhYp50FYZR9q8_X5KF4=";
+
+static const uint8_t DECODED_PUBLIC_KEY[32] = {0x6a, 0xa0, 0x3d, 0xca, 0xa7, 0xb5, 0x45, 0x7a, 0x0e, 0x4f, 0xa1, 0xeb, 0x98, 0x26, 0xc5, 0xe3, 0x4c, 0x15, 0x52, 0x16, 0x29, 0xe7, 0x41, 0x58, 0x65, 0x1f, 0x6a, 0xf3, 0xf5, 0xf9, 0x28, 0x5e};
+
+static void test_parse_public_key() {
+  uint8_t decoded[GLOME_MAX_PUBLIC_KEY_LENGTH] = {0};
+  g_assert_true(
+      glome_login_parse_public_key(ENCODED_PUBLIC_KEY, decoded, sizeof(decoded)));
+  g_assert_cmpmem(decoded, sizeof(decoded), DECODED_PUBLIC_KEY, sizeof(DECODED_PUBLIC_KEY));
+
+  g_assert_false(
+      glome_login_parse_public_key(ENCODED_PUBLIC_KEY, decoded, sizeof(decoded) - 1));
+  g_assert_false(glome_login_parse_public_key(
+      "glome-group1-md5 QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=", decoded,
+      sizeof(decoded)));
+  g_assert_false(glome_login_parse_public_key("glome-v1 QUFBQUFBQUFB", decoded,
+                                              sizeof(decoded)));
+
+  memset(decoded, 0, sizeof(decoded));
+  const char* extra_chars =
+      "glome-v1 \t aqA9yqe1RXoOT6HrmCbF40wVUhYp50FYZR9q8_X5KF4= "
+      "root@localhost";
+  g_assert_true(
+      glome_login_parse_public_key(extra_chars, decoded, sizeof(decoded)));
+  g_assert_cmpmem(decoded, sizeof(decoded), DECODED_PUBLIC_KEY, sizeof(DECODED_PUBLIC_KEY));
+}
+
+int main(int argc, char** argv) {
+  g_test_init(&argc, &argv, NULL);
+
+  g_test_add_func("/test-parse-public-key", test_parse_public_key);
+
+  return g_test_run();
+}

--- a/login/config_test.cfg
+++ b/login/config_test.cfg
@@ -1,0 +1,13 @@
+auth-delay = 7
+input-timeout = 321
+host-id = my-host
+login-path = /bin/true
+disable-syslog = yes
+print-secrets = 0
+verbose = true
+
+[service]
+# Corresponding private key: 6aa03dcaa7b5457a0e4fa1eb9826c5e34c15521629e74158651f6af3f5f9285e
+public-key = glome-v1 aqA9yqe1RXoOT6HrmCbF40wVUhYp50FYZR9q8_X5KF4=
+key-version = 42
+url-prefix = glome://

--- a/login/login_test.c
+++ b/login/login_test.c
@@ -133,39 +133,12 @@ static void test_vector_2() {
   }
 }
 
-static void test_parse_public_key() {
-  const char* encoded = "glome-v1 QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=";
-  uint8_t decoded[GLOME_MAX_PUBLIC_KEY_LENGTH] = {0};
-  uint8_t expected[GLOME_MAX_PUBLIC_KEY_LENGTH] =
-      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-  g_assert_true(
-      glome_login_parse_public_key(encoded, decoded, sizeof(decoded)));
-  g_assert_cmpmem(decoded, sizeof(decoded), expected, sizeof(expected));
-
-  g_assert_false(
-      glome_login_parse_public_key(encoded, decoded, sizeof(decoded) - 1));
-  g_assert_false(glome_login_parse_public_key(
-      "glome-group1-md5 QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=", decoded,
-      sizeof(decoded)));
-  g_assert_false(glome_login_parse_public_key("glome-v1 QUFBQUFBQUFB", decoded,
-                                              sizeof(decoded)));
-
-  memset(decoded, 0, sizeof(decoded));
-  const char* extra_chars =
-      "glome-v1 \t QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE= "
-      "root@localhost";
-  g_assert_true(
-      glome_login_parse_public_key(extra_chars, decoded, sizeof(decoded)));
-  g_assert_cmpmem(decoded, sizeof(decoded), expected, sizeof(expected));
-}
-
 int main(int argc, char** argv) {
   g_test_init(&argc, &argv, NULL);
 
   g_test_add_func("/test-shell-action", test_shell_action);
   g_test_add_func("/test-vector-1", test_vector_1);
   g_test_add_func("/test-vector-2", test_vector_2);
-  g_test_add_func("/test-parse-public-key", test_parse_public_key);
 
   return g_test_run();
 }

--- a/login/meson.build
+++ b/login/meson.build
@@ -64,7 +64,7 @@ if get_option('tests')
         dependencies : [openssl_dep, glib_dep],
         link_with : [glome_lib, login_lib],
         include_directories : glome_incdir)
-    test('config test', config_test)
+    test('config test', config_test, args: files('config_test.cfg'))
 endif
 
 if get_option('pam-glome')

--- a/login/meson.build
+++ b/login/meson.build
@@ -58,6 +58,13 @@ if get_option('tests')
         link_with : [glome_lib, login_lib],
         include_directories : glome_incdir)
     test('crypto test', crypto_test)
+
+    config_test = executable(
+        'config_test', 'config_test.c',
+        dependencies : [openssl_dep, glib_dep],
+        link_with : [glome_lib, login_lib],
+        include_directories : glome_incdir)
+    test('config test', config_test)
 endif
 
 if get_option('pam-glome')


### PR DESCRIPTION
commit da09fec7b871fffd932f4f8d93576a88cf10a8f3 (HEAD -> public-key-format, burgerdev/public-key-format)
Author: Markus Rudy <markusrudy@google.com>
Date:   Mon Jan 16 16:29:24 2023 +0100

    Test all supported config file keys

    Introduce a new config file only for testing so that we can add a public
    key to it without adding it to the file that is packaged/installed.

commit 82d3e66c346a04db8f6cfd379d7a7e93be3fc6a7
Author: Markus Rudy <markusrudy@google.com>
Date:   Mon Jan 16 13:58:06 2023 +0100

    Clarify format of public key at rest

    The public key format specified in RFD002 mandated standard
    Base64-encoding, but the implementation uses URL-safe Base64. We want to
    use the URL-safe format to be consistent with the challenge encoding.

    This also introduces a dedicated test for the login module.