### PR TITLE
Update Docker scripts for new public key format

### DIFF
--- a/kokoro/docker/Dockerfile
+++ b/kokoro/docker/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
        openssh-server \
        socat \
-       xxd \
     && rm -rf /var/lib/apt/lists/*
 CMD ["/usr/local/sbin/glome-start"]
 EXPOSE 22 23

--- a/kokoro/docker/glome-start
+++ b/kokoro/docker/glome-start
@@ -4,13 +4,10 @@ GLOME=/usr/local/bin/glome
 GLOME_LOGIN=/usr/local/sbin/glome-login
 CONFIG=/usr/local/etc/glome/config
 PRIVATE=/usr/local/etc/glome/private.key
-PUBLIC=/usr/local/etc/glome/public.key
 
 umask 077
-$GLOME genkey | tee $PRIVATE | $GLOME pubkey > $PUBLIC
-
-PUBLIC_HEX=$(xxd -c 32 -ps $PUBLIC)
-sed -i "s/^#key = .*/key = $PUBLIC_HEX/" $CONFIG
+PUBLIC_KEY=$($GLOME genkey | tee $PRIVATE | $GLOME pubkey)
+sed -i "s/^#public-key = .*/public-key = $PUBLIC_KEY/" $CONFIG
 sed -i "1 i\auth sufficient /usr/local/lib/x86_64-linux-gnu/security/pam_glome.so" /etc/pam.d/sshd
 cat <<EOF > /etc/ssh/sshd_config.d/glome.conf
 ChallengeResponseAuthentication yes

--- a/login/example.cfg
+++ b/login/example.cfg
@@ -7,6 +7,6 @@
 #
 # For more details about the format of this file see README.md.
 #
-#key = 5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb
+#public-key = glome-v1 5UvwOKcv-6n_1bo7UAA7-XVqf9ggzHQsbaxptXNsagg=
 key-version = 1
 #prompt = https://glome.example.com/


### PR DESCRIPTION
Also updates the example config to use public-key instead of key.