### PR TITLE
Fix setting of prompt parameter

### DIFF
--- a/login/config.c
+++ b/login/config.c
@@ -280,13 +280,9 @@ static status_t assign_service_option(glome_login_config_t *config,
   } else if (strcmp(key, "url-prefix") == 0) {
     // `url-prefix` support is provided only for backwards-compatiblity
     // TODO: to be removed in the 1.0 release
-    if (config->prompt == NULL) {
-      return assign_string_option(&config->prompt, val);
-    }
+    return assign_string_option(&config->prompt, val);
   } else if (strcmp(key, "prompt") == 0) {
-    if (config->prompt == NULL) {
-      return assign_string_option(&config->prompt, val);
-    }
+    return assign_string_option(&config->prompt, val);
   } else if (strcmp(key, "public-key") == 0) {
     if (!glome_login_parse_public_key(val, config->service_key,
                                       sizeof(config->service_key))) {

--- a/login/config_test.c
+++ b/login/config_test.c
@@ -58,6 +58,7 @@ static void test_parse_config_file() {
   g_assert_true(EXAMPLE_CFG != NULL);
 
   glome_login_config_t config = {0};
+  default_config(&config);
   config.config_path = EXAMPLE_CFG;
 
   status_t s = glome_login_parse_config_file(&config);

--- a/login/pam.c
+++ b/login/pam.c
@@ -53,7 +53,7 @@ static const char *arg_value(const char *arg, const char *key,
 
 static int parse_pam_args(pam_handle_t *pamh, int argc, const char **argv,
                           glome_login_config_t *config) {
-  memset(config, 0, sizeof(glome_login_config_t));
+  default_config(config);
   int errors = 0;
   status_t status;
   const char *val;

--- a/login/ui.c
+++ b/login/ui.c
@@ -111,7 +111,7 @@ static const char flags_help[] =
     "\n -M, --host-id=NAME         use NAME as the host-id"
     "\n";
 
-static const char* short_options = "hc:d:k:l:st:u:vIK:M:";
+static const char* short_options = "hc:d:k:l:p:st:u:vIK:M:";
 static const struct option long_options[] = {
     {"help", no_argument, 0, 'h'},
     {"config-path", required_argument, 0, 'c'},
@@ -128,7 +128,7 @@ static const struct option long_options[] = {
     {0, 0, 0, 0},
 };
 
-int parse_args(glome_login_config_t* config, int argc, char* argv[]) {
+void default_config(glome_login_config_t* config) {
   memset(config, 0, sizeof(glome_login_config_t));
 
   // Setting defaults.
@@ -137,6 +137,10 @@ int parse_args(glome_login_config_t* config, int argc, char* argv[]) {
   config->auth_delay_sec = DEFAULT_AUTH_DELAY;
   config->input_timeout_sec = DEFAULT_INPUT_TIMEOUT;
   config->options = SYSLOG;
+}
+
+int parse_args(glome_login_config_t* config, int argc, char* argv[]) {
+  default_config(config);
 
   int c;
   int errors = 0;
@@ -161,7 +165,7 @@ int parse_args(glome_login_config_t* config, int argc, char* argv[]) {
                                                   "login-path", optarg);
         break;
       case 'p':
-        status = glome_login_assign_config_option(config, "default", "prompt",
+        status = glome_login_assign_config_option(config, "service", "prompt",
                                                   optarg);
         break;
       case 's':

--- a/login/ui.h
+++ b/login/ui.h
@@ -46,6 +46,9 @@
 // decode_hex converts a hex-encoded string into the equivalent bytes.
 int decode_hex(uint8_t* dst, size_t dst_len, const char* in);
 
+// default_config initializes the config with the default values.
+void default_config(glome_login_config_t* config);
+
 // parse_args parses command-line arguments into a config struct. It will
 // forcefully initialize the whole content of the struct to zero.
 int parse_args(glome_login_config_t* config, int argc, char* argv[]);


### PR DESCRIPTION
Prompt can't be set if it has a default value:

   ERROR: unrecognized service option: prompt

Also fix setting of prompt from the short command parameter and make sure default prompt is always set (was empty for PAM module).