### PR TITLE
Insert a slash after url-prefix when writing it into prompt

### DIFF
--- a/login/config.c
+++ b/login/config.c
@@ -280,7 +280,16 @@ static status_t assign_service_option(glome_login_config_t *config,
   } else if (strcmp(key, "url-prefix") == 0) {
     // `url-prefix` support is provided only for backwards-compatiblity
     // TODO: to be removed in the 1.0 release
-    return assign_string_option(&config->prompt, val);
+    size_t len = strlen(val);
+    char *url_prefix = malloc(len + 2);
+    if (url_prefix == NULL) {
+      return status_createf("ERROR: failed to allocate memory for url_prefix");
+    }
+    strncpy(url_prefix, val, len + 1);
+    url_prefix[len] = '/';
+    url_prefix[len + 1] = '\0';
+    config->prompt = url_prefix;
+    return STATUS_OK;
   } else if (strcmp(key, "prompt") == 0) {
     return assign_string_option(&config->prompt, val);
   } else if (strcmp(key, "public-key") == 0) {

--- a/login/config_test_url-prefix.cfg
+++ b/login/config_test_url-prefix.cfg
@@ -1,0 +1,13 @@
+auth-delay = 7
+input-timeout = 321
+host-id = my-host
+login-path = /bin/true
+disable-syslog = yes
+print-secrets = 0
+verbose = true
+
+[service]
+# Corresponding private key: 6aa03dcaa7b5457a0e4fa1eb9826c5e34c15521629e74158651f6af3f5f9285e
+public-key = glome-v1 aqA9yqe1RXoOT6HrmCbF40wVUhYp50FYZR9q8_X5KF4=
+key-version = 42
+url-prefix = glome:/

--- a/login/meson.build
+++ b/login/meson.build
@@ -65,6 +65,7 @@ if get_option('tests')
         link_with : [glome_lib, login_lib],
         include_directories : glome_incdir)
     test('config test', config_test, args: files('config_test.cfg'))
+    test('config test with url-prefix', config_test, args: files('config_test_url-prefix.cfg'))
 endif
 
 if get_option('pam-glome')


### PR DESCRIPTION
We previously had URLs like "url-prefix = http://otac" that got /v1/[...] appended. With the recent changes to prompt the slash before v1 was dropped, which makes these URL prefixes invalid. As we are dropping url-prefix before v1 anyway, let's fork the config and add some more compatibility code to ease the migration to prompt.