### PR TITLE
Parse command line again after reading the config

### DIFF
--- a/login/main.c
+++ b/login/main.c
@@ -33,6 +33,7 @@ static void handle_error(const char* error_tag) {
 int main(int argc, char* argv[]) {
   glome_login_config_t config = {0};
 
+  // Parse arguments to initialize the config path.
   int r = parse_args(&config, argc, argv);
   if (r > 0) {
     return EXITCODE_USAGE;
@@ -42,9 +43,25 @@ int main(int argc, char* argv[]) {
     return EXITCODE_PANIC;
   }
 
+  // Reset config while preserving the config path.
+  const char* config_path = config.config_path;
+  default_config(&config);
+  config.config_path = config_path;
+
+  // Read configuration file.
   status_t status = glome_login_parse_config_file(&config);
   if (status != STATUS_OK) {
     handle_error(status);
+    return EXITCODE_PANIC;
+  }
+
+  // Parse arguments again to override config values.
+  r = parse_args(&config, argc, argv);
+  if (r > 0) {
+    return EXITCODE_USAGE;
+  }
+  if (r < 0) {
+    handle_error("parse-args");
     return EXITCODE_PANIC;
   }
 

--- a/login/pam.c
+++ b/login/pam.c
@@ -53,7 +53,6 @@ static const char *arg_value(const char *arg, const char *key,
 
 static int parse_pam_args(pam_handle_t *pamh, int argc, const char **argv,
                           glome_login_config_t *config) {
-  default_config(config);
   int errors = 0;
   status_t status;
   const char *val;
@@ -205,16 +204,30 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
   glome_login_config_t config = {0};
   int rc = PAM_AUTH_ERR;
 
+  // Parse arguments to initialize the config path.
   int r = parse_pam_args(pamh, argc, argv, &config);
   if (r < 0) {
     pam_syslog(pamh, LOG_ERR, "failed to parse pam module arguments (%d)", r);
     return rc;
   }
 
+  // Reset config while preserving the config path.
+  const char *config_path = config.config_path;
+  default_config(&config);
+  config.config_path = config_path;
+
+  // Read configuration file.
   status_t status = glome_login_parse_config_file(&config);
   if (status != STATUS_OK) {
     pam_syslog(pamh, LOG_ERR, "failed to read config file %s: %s",
                config.config_path, status);
+    return rc;
+  }
+
+  // Parse arguments again to override config values.
+  r = parse_pam_args(pamh, argc, argv, &config);
+  if (r < 0) {
+    pam_syslog(pamh, LOG_ERR, "failed to parse pam module arguments (%d)", r);
     return rc;
   }
 

--- a/login/ui.c
+++ b/login/ui.c
@@ -140,11 +140,13 @@ void default_config(glome_login_config_t* config) {
 }
 
 int parse_args(glome_login_config_t* config, int argc, char* argv[]) {
-  default_config(config);
-
   int c;
   int errors = 0;
   status_t status;
+
+  // Reset current position to allow parsing arguments multiple times.
+  optind = 1;
+
   while ((c = getopt_long(argc, argv, short_options, long_options, NULL)) !=
          -1) {
     switch (c) {


### PR DESCRIPTION
This way command line options can override the settings in the configuration file. Same goes for the PAM options.