### PR TITLE
State that devices require randomness for the protocol to work

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -32,6 +32,8 @@ a human operator to access a device with the following constraints:
 *   The device does not have a synchronized time (e.g. no real-time clock).
 *   The device does not store any secrets (e.g. all its storage is easily
     readable by an adversary).
+*   The device has access to randomness (e.g. a hardware-based random number
+    generator).
 *   The device accepts input from a human operator via a very low-bandwidth
     device (e.g. a keyboard).
 *   The device provides output to a human operator (e.g. via display).

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -32,7 +32,7 @@ a human operator to access a device with the following constraints:
 *   The device does not have a synchronized time (e.g. no real-time clock).
 *   The device does not store any secrets (e.g. all its storage is easily
     readable by an adversary).
-*   The device has access to randomness (e.g. a hardware-based random number
+*   The device has access to a [cryptographically secure pseudorandom number generator](https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator) (e.g. a hardware-based random number
     generator).
 *   The device accepts input from a human operator via a very low-bandwidth
     device (e.g. a keyboard).


### PR DESCRIPTION
The ephemeral key generated by Alice must not be predictable. The protocol should not leak anything about the key right now as it gets munged into the elliptic curve calculation, but if the PRNG seed is known or it is seeded from predictable information (like time), then it might be possible to do an offline attack on the key space. The timeout helps us here, but only if the key space is large enough.