### PR TITLE
Avoid calling openlog when using GLOME as a library

### DIFF
--- a/login/login.c
+++ b/login/login.c
@@ -238,7 +238,7 @@ void login_syslog(glome_login_config_t* config, pam_handle_t* pamh,
   if (config->options & SYSLOG) {
     va_list args;
     va_start(args, format);
-    vsyslog(priority, format, args);
+    vsyslog(LOG_MAKEPRI(LOG_AUTH, priority), format, args);
     va_end(args);
   }
 }
@@ -516,9 +516,6 @@ int login_run(glome_login_config_t* config, const char** error_tag) {
         "debug: auth delay: %d seconds\n",
         config->options, config->username, config->login_path,
         config->auth_delay_sec);
-  }
-  if (config->options & SYSLOG) {
-    openlog("glome-login", LOG_PID | LOG_CONS, LOG_AUTH);
   }
 
   int r = login_authenticate(config, NULL, error_tag);

--- a/login/main.c
+++ b/login/main.c
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <stdlib.h>
+#include <syslog.h>
 #include <unistd.h>
 
 #include "config.h"
@@ -63,6 +64,11 @@ int main(int argc, char* argv[]) {
   if (r < 0) {
     handle_error("parse-args");
     return EXITCODE_PANIC;
+  }
+
+  // Initialize syslog, if we're going to log.
+  if (config.options & SYSLOG) {
+    openlog(NULL, LOG_PID | LOG_CONS, LOG_AUTH);
   }
 
   const char* error_tag = NULL;


### PR DESCRIPTION
This causes log lines to always use `glome-login` as the ident, which isn't necessarily desirable.

We can just not call openlog: if we don't call it, syslog will initialise with some default values (i.e. not including the PID), so this won't _break_ any users of GLOME-as-a-library who don't update to call `openlog`. To avoid this then logging to the wrong facility we update our own calls to syslog to explicitly set the facility.

PAM doesn't need a facility; it appears to just use LOG_AUTHPRIV internally.