### PR TITLE
Fix build failure on Debian unstable

### DIFF
--- a/login/meson.build
+++ b/login/meson.build
@@ -92,7 +92,7 @@ if get_option('pam-glome')
             pam_test = executable(
                 'pam_test', 'pam_test.c',
                 dependencies : [libpamtest],
-                c_args : oldstyle_run_pamtest ? '-DOLDSTYLE_RUN_PAMTEST' : '')
+                c_args : oldstyle_run_pamtest ? '-DOLDSTYLE_RUN_PAMTEST' : [])
             custom_target('pam_service',
                 build_by_default : true, output : [ 'pam_service' ],
                 command : [ 'mkdir', '@OUTPUT@' ])


### PR DESCRIPTION
Empty string gets interpreted as a file name:

FAILED: login/pam_test.p/pam_test.c.o
cc -Ilogin/pam_test.p -Ilogin -I../login -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wal l -Winvalid-pch -Wextra -Wpedantic -std=c99 '-DSYSCONFDIR="/etc"' -D_POSIX_C_SOURCE=200809L -DO PENSSL_API_COMPAT=10100 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -f stack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_ SOURCE=2 '' -MD -MQ login/pam_test.p/pam_test.c.o -MF login/pam_test.p/pam_test.c.o.d -o login/ pam_test.p/pam_test.c.o -c ../login/pam_test.c
cc: warning: : linker input file unused because linking not done
cc: error: : linker input file not found: No such file or directory