### PR TITLE
Disable bracketed paste

### DIFF
--- a/login/login.c
+++ b/login/login.c
@@ -41,6 +41,7 @@
 #include "ui.h"
 
 #define PROMPT "> "
+#define BRACKETED_PASTE_FINISH "\033[?2004l\r"
 
 #define DMI_UUID_PATH "/sys/class/dmi/id/product_uuid"
 #define DMI_UUID_SIZE 36
@@ -269,6 +270,10 @@ int login_prompt(glome_login_config_t* config, pam_handle_t* pamh,
                  size_t input_size) {
   UNUSED(pamh);
   UNUSED(error_tag);
+
+  // Disable bracketed paste. Special characters in the auth tag cause
+  // authentication to fail.
+  puts(BRACKETED_PASTE_FINISH);
 
   puts(message);
   fputs(PROMPT, stdout);


### PR DESCRIPTION
In some settings we seem to end up with users' terminals being confused and willing to send bracketed paste escape codes, which then cause authentication to fail. Even worse it looks like the special characters are not displayed in some shells, thus confusing users as to what just happened.

Although to be honest: I have not found the specific environment where this breaks in a reproducible fashion and this is effectively defence in depth.