### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/presubmit-python.yml
+++ b/.github/workflows/presubmit-python.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Per https://devguide.python.org/versions/ 3.8 is running out of security support soon (and is ancient), 3.9-3.11 are security supported and 3.12 is receiving bugfixes. The workflows stopped running because of these ancient matrix nodes.