### PR TITLE
cli/test.sh: Ignore shellcheck error

### DIFF
--- a/cli/test.sh
+++ b/cli/test.sh
@@ -24,6 +24,7 @@ fi
 
 t=$(mktemp -d)
 cleanup() {
+  # shellcheck disable=SC2317
   rm -rf -- "${t?}"
 }
 trap cleanup EXIT


### PR DESCRIPTION
cleanup() is invoked by a trap, which per https://www.shellcheck.net/wiki/SC2317 needs manual ignoring.