### PR TITLE
Add missing fields to Cargo.toml

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "glome"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "clap",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "glome"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
+
+description = "Generic low-overhead message exchange with cryptographic integrity protection"
+repository = "https://github.com/google/glome"
+license = "Apache-2.0"
+categories = ["authentication", "cryptography", "no-std"]
 
 [features]
 default = [ "dalek" ]


### PR DESCRIPTION
Some of these fields are required for publishing to crates.io, some fields are just nice-to-have. The version change anticipates the next release number, including this commit, for publishing.

Fixes #204