### PR TITLE
Remove cpplint from presubmit-c.yml

### DIFF
--- a/.github/workflows/presubmit-c.yml
+++ b/.github/workflows/presubmit-c.yml
@@ -15,12 +15,6 @@ jobs:
       run: |
         find . '(' -name '*.c' -or -name '*.h' ')' -print0 | \
           xargs -0 --verbose -- clang-format --Werror --dry-run
-  cpplint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: cpplint
-      run: pip install cpplint && cpplint --recursive .
   test-linux:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
cpplint had some questionable history and they don't seem to release the fix to handle .c files sanely. Maybe it was not the right decision to lint C files with a C++ linter in the first place, so let's remove it.

Fixes #197