### PR TITLE
Include README.md in published crate

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 description = "Generic low-overhead message exchange with cryptographic integrity protection"
 repository = "https://github.com/google/glome"
+readme = "../README.md"
 license = "Apache-2.0"
 categories = ["authentication", "cryptography", "no-std"]
 


### PR DESCRIPTION
Relative paths work correctly:

```console
$ cargo publish --dry-run
[...]
$ tar tzf target/package/glome-0.3.0.crate
glome-0.3.0/.cargo_vcs_info.json
glome-0.3.0/Cargo.lock
glome-0.3.0/Cargo.toml
glome-0.3.0/Cargo.toml.orig
glome-0.3.0/README.md
glome-0.3.0/src/cli/bin.rs
glome-0.3.0/src/dalek.rs
glome-0.3.0/src/lib.rs
glome-0.3.0/src/openssl.rs
```