### PR TITLE
Fix another use of error in test format string

### DIFF
--- a/go/glome/glome_test.go
+++ b/go/glome/glome_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 )
 
-func handle(e error, t *testing.T) {
-	if e != nil {
-		t.Fatalf("Unexpected Error: " + e.Error())
+func handle(err error, t *testing.T) {
+	if err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Apparently I missed this one and my local toolchain did not complain.

Who wrote this code even (I didn't check), using `e` for errors... :>