### PR TITLE
CLI Truncated Tag Authentication fix

### DIFF
--- a/cli/commands.c
+++ b/cli/commands.c
@@ -257,6 +257,10 @@ int verify(int argc, char **argv) {
   if (expected_tag_len > sizeof tag) {
     expected_tag_len = sizeof tag;
   }
+  if (expected_tag_len < sizeof tag) {
+    fputs("MAC tag verification failed\n", stderr);
+    goto out;
+  }
 
   // compare the tag
   if (CRYPTO_memcmp(expected_tag, tag, expected_tag_len) != 0) {


### PR DESCRIPTION
The CLI `verify` command accepts truncated authentication tags of arbitrary length, including a single byte. The verification routine base64url-decodes the user-supplied `--tag` argument and uses the *decoded length* as the comparison length for `CRYPTO_memcmp()`. No minimum tag length is enforced. An attacker supplying a 1-byte tag only needs to match the first byte of the real tag.



